### PR TITLE
Add color selection to notes graph

### DIFF
--- a/notas_derivadas.py
+++ b/notas_derivadas.py
@@ -1,8 +1,20 @@
 import tkinter as tk
-from tkinter import messagebox
+from tkinter import messagebox, colorchooser
 import numpy as np
 import matplotlib.pyplot as plt
 from scipy.interpolate import make_interp_spline
+
+# Color de la línea de las notas. Comienza con verde por defecto
+color_linea = "#008000"
+
+
+def elegir_color():
+    """Abre un selector de color para la línea de notas."""
+    global color_linea
+    color = colorchooser.askcolor(title="Elige color de la línea de notas")
+    if color[1] is not None:
+        color_linea = color[1]
+        color_muestra.config(bg=color_linea)
 
 def graficar_notas_y_derivada(notas):
     if len(notas) < 4:
@@ -17,7 +29,7 @@ def graficar_notas_y_derivada(notas):
     derivada = spline.derivative()(tiempo_suave)
 
     fig, ax1 = plt.subplots()
-    ax1.plot(tiempo_suave, notas_suave, color='green', label='Notas')
+    ax1.plot(tiempo_suave, notas_suave, color=color_linea, label='Notas')
     ax1.set_xlabel('Número de prueba')
     ax1.set_ylabel('Nota', color='blue')
     ax1.tick_params(axis='y', labelcolor='blue')
@@ -51,6 +63,14 @@ label.pack(pady=10)
 
 entry = tk.Entry(ventana, width=50)
 entry.pack()
+
+# Botón para elegir el color de la línea de notas
+color_boton = tk.Button(ventana, text="Elegir color de línea", command=elegir_color)
+color_boton.pack(pady=5)
+
+# Muestra del color seleccionado
+color_muestra = tk.Label(ventana, width=10, bg=color_linea, relief=tk.SUNKEN)
+color_muestra.pack()
 
 boton = tk.Button(ventana, text="Graficar", command=procesar_entrada)
 boton.pack(pady=10)


### PR DESCRIPTION
## Summary
- add a `color_linea` global variable with a default green color
- include a new `elegir_color` function using `colorchooser` to select the line color
- use the selected color when plotting
- provide a button and color preview in the Tkinter UI

## Testing
- `python -m py_compile notas_derivadas.py`

------
https://chatgpt.com/codex/tasks/task_e_68699a3a1aac832db5fe3dc01bc7c325